### PR TITLE
Shiva dev

### DIFF
--- a/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -251,6 +251,10 @@ public:
     return IsConstantImm && isUInt<12>(Imm) && VK == RISCVMCExpr::VK_RISCV_None;
   }
 
+  bool isSImm9Lsb0() const { return isBareSimmNLsb0<9>(); }
+
+  bool isSImm12Lsb0() const { return isBareSimmNLsb0<12>(); }
+
   bool isSImm13Lsb0() const { return isBareSimmNLsb0<13>(); }
 
   bool isUImm20() const {
@@ -498,6 +502,14 @@ bool RISCVAsmParser::MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
                                       (1 << 11) - 1);
   case Match_InvalidUImm12:
     return generateImmOutOfRangeError(Operands, ErrorInfo, 0, (1 << 12) - 1);
+  case Match_InvalidSImm9Lsb0:
+    return generateImmOutOfRangeError(
+        Operands, ErrorInfo, -(1 << 8), (1 << 8) - 2,
+        "immediate must be a multiple of 2 bytes in the range");
+  case Match_InvalidSImm12Lsb0:
+    return generateImmOutOfRangeError(
+        Operands, ErrorInfo, -(1 << 11), (1 << 11) - 2,
+        "immediate must be a multiple of 2 bytes in the range");
   case Match_InvalidSImm13Lsb0:
     return generateImmOutOfRangeError(
         Operands, ErrorInfo, -(1 << 12), (1 << 12) - 2,

--- a/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -226,6 +226,22 @@ public:
            (VK == RISCVMCExpr::VK_RISCV_None || VK == RISCVMCExpr::VK_RISCV_LO);
   }
 
+  bool isUImm8Lsb00() const {
+    int64_t Imm;
+    RISCVMCExpr::VariantKind VK;
+    bool IsConstantImm = evaluateConstantImm(Imm, VK);
+    return IsConstantImm && isShiftedUInt<6, 2>(Imm) &&
+           VK == RISCVMCExpr::VK_RISCV_None;
+  }
+
+  bool isUImm7Lsb00() const {
+    int64_t Imm;
+    RISCVMCExpr::VariantKind VK;
+    bool IsConstantImm = evaluateConstantImm(Imm, VK);
+    return IsConstantImm && isShiftedUInt<5, 2>(Imm) &&
+           VK == RISCVMCExpr::VK_RISCV_None;
+  }
+
   bool isUImm12() const {
     int64_t Imm;
     RISCVMCExpr::VariantKind VK;
@@ -492,6 +508,14 @@ bool RISCVAsmParser::MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
     return generateImmOutOfRangeError(
         Operands, ErrorInfo, -(1 << 20), (1 << 20) - 2,
         "immediate must be a multiple of 2 bytes in the range");
+  case Match_InvalidUImm7Lsb00:
+    return generateImmOutOfRangeError(
+        Operands, ErrorInfo, 0, (1 << 7) - 4,
+        "immediate must be a multiple of 4 bytes in the range");
+  case Match_InvalidUImm8Lsb00:
+    return generateImmOutOfRangeError(
+        Operands, ErrorInfo, 0, (1 << 8) - 4,
+        "immediate must be a multiple of 4 bytes in the range");
   case Match_InvalidFenceArg: {
     SMLoc ErrorLoc = ((RISCVOperand &)*Operands[ErrorInfo]).getStartLoc();
     return Error(

--- a/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -148,7 +148,12 @@ static DecodeStatus DecodeFPR64RegisterClass(MCInst &Inst, uint64_t RegNo,
 // in bit field)
 static void addImplySP(MCInst &Inst, int64_t Address, const void *Decoder) {
   if (Inst.getOpcode() == RISCV::CLWSP ||
-      Inst.getOpcode() == RISCV::CSWSP) {
+      Inst.getOpcode() == RISCV::CSWSP ||
+      Inst.getOpcode() == RISCV::CADDI4SPN) {
+    DecodeGPRRegisterClass(Inst, 2, Address, Decoder);
+  }
+  if (Inst.getOpcode() == RISCV::CADDI16SP) {
+    DecodeGPRRegisterClass(Inst, 2, Address, Decoder);
     DecodeGPRRegisterClass(Inst, 2, Address, Decoder);
   }
 }
@@ -167,6 +172,8 @@ template <unsigned N>
 static DecodeStatus decodeSImmOperand(MCInst &Inst, uint64_t Imm,
                                       int64_t Address, const void *Decoder) {
   assert(isUInt<N>(Imm) && "Invalid immediate");
+
+  addImplySP(Inst, Address, Decoder);
   // Sign-extend the number in the bottom N bits of Imm
   Inst.addOperand(MCOperand::createImm(SignExtend64<N>(Imm)));
   return MCDisassembler::Success;

--- a/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVAsmBackend.cpp
@@ -62,7 +62,9 @@ public:
       { "fixup_riscv_lo12_s",      0,     32,  0 },
       { "fixup_riscv_pcrel_hi20", 12,     20,  MCFixupKindInfo::FKF_IsPCRel },
       { "fixup_riscv_jal",        12,     20,  MCFixupKindInfo::FKF_IsPCRel },
-      { "fixup_riscv_branch",      0,     32,  MCFixupKindInfo::FKF_IsPCRel }
+      { "fixup_riscv_branch",      0,     32,  MCFixupKindInfo::FKF_IsPCRel },
+      { "fixup_riscv_rvc_jump",    2,     11,  MCFixupKindInfo::FKF_IsPCRel },
+      { "fixup_riscv_rvc_branch",  2,     11,  MCFixupKindInfo::FKF_IsPCRel }
     };
 
     if (Kind < FirstTargetFixupKind)
@@ -151,8 +153,44 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
     Value = (Sbit << 31) | (Mid6 << 25) | (Lo4 << 8) | (Hi1 << 7);
     return Value;
   }
+  case RISCV::fixup_riscv_rvc_jump: {
+    // Need to produce offset[11|4|9:8|10|6|7|3:1|5] from the 11-bit Value.
+    unsigned Bit11  = (Value >> 11) & 0x1;
+    unsigned Bit4   = (Value >> 4) & 0x1;
+    unsigned Bit9_8 = (Value >> 8) & 0x3;
+    unsigned Bit10  = (Value >> 10) & 0x1;
+    unsigned Bit6   = (Value >> 6) & 0x1;
+    unsigned Bit7   = (Value >> 7) & 0x1;
+    unsigned Bit3_1 = (Value >> 1) & 0x7;
+    unsigned Bit5   = (Value >> 5) & 0x1;
+    Value = (Bit11 << 10) | (Bit4 << 9) | (Bit9_8 << 7) | (Bit10 << 6) |
+            (Bit6 << 5) | (Bit7 << 4) | (Bit3_1 << 1) | Bit5;
+    return Value;
+  }
+  case RISCV::fixup_riscv_rvc_branch: {
+    // Need to produce offset[8|4:3], [reg 3 bit], offset[7:6|2:1|5]
+    unsigned Bit8   = (Value >> 8) & 0x1;
+    unsigned Bit7_6 = (Value >> 6) & 0x3;
+    unsigned Bit5   = (Value >> 5) & 0x1;
+    unsigned Bit4_3 = (Value >> 3) & 0x3;
+    unsigned Bit2_1 = (Value >> 1) & 0x3;
+    Value = (Bit8 << 10) | (Bit4_3 << 8) | (Bit7_6 << 3) |
+            (Bit2_1 << 1) | Bit5;
+    return Value;
+  }
 
   }
+}
+
+static unsigned getSize(unsigned Kind) {
+  switch (Kind) {
+  default:
+    return 4;
+  case RISCV::fixup_riscv_rvc_jump:
+  case RISCV::fixup_riscv_rvc_branch:
+    return 2;
+  }
+  return 4;
 }
 
 void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
@@ -172,11 +210,12 @@ void RISCVAsmBackend::applyFixup(const MCAssembler &Asm, const MCFixup &Fixup,
   Value <<= Info.TargetOffset;
 
   unsigned Offset = Fixup.getOffset();
+  unsigned FullSize = getSize(Fixup.getKind());
   assert(Offset + NumBytes <= Data.size() && "Invalid fixup offset!");
 
   // For each byte of the fragment that the fixup touches, mask in the
   // bits from the fixup value.
-  for (unsigned i = 0; i != 4; ++i) {
+  for (unsigned i = 0; i != FullSize; ++i) {
     Data[Offset + i] |= uint8_t((Value >> (i * 8)) & 0xff);
   }
   return;

--- a/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -30,7 +30,10 @@ enum {
   InstFormatB = 5,
   InstFormatU = 6,
   InstFormatJ = 7,
-  InstFormatOther = 8,
+  InstFormatC = 8,
+  InstFormatCB = 9,
+  InstFormatCJ = 10,
+  InstFormatOther = 11,
 
   InstFormatMask = 15
 };

--- a/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
@@ -58,6 +58,10 @@ unsigned RISCVELFObjectWriter::getRelocType(MCContext &Ctx,
     return ELF::R_RISCV_JAL;
   case RISCV::fixup_riscv_branch:
     return ELF::R_RISCV_BRANCH;
+  case RISCV::fixup_riscv_rvc_jump:
+    return ELF::R_RISCV_RVC_JUMP;
+  case RISCV::fixup_riscv_rvc_branch:
+    return ELF::R_RISCV_RVC_BRANCH;
   }
 }
 

--- a/lib/Target/RISCV/MCTargetDesc/RISCVFixupKinds.h
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVFixupKinds.h
@@ -35,6 +35,12 @@ enum Fixups {
   // fixup_riscv_branch - 12-bit fixup for symbol references in the branch
   // instructions
   fixup_riscv_branch,
+  // fixup_riscv_rvc_jump - 11-bit fixup for symbol references in the
+  // compressed instruction
+  fixup_riscv_rvc_jump,
+  // fixup_riscv_rvc_branch - 8-bit fixup for symbol references in the
+  // compressed branch instruction
+  fixup_riscv_rvc_branch,
 
   // fixup_riscv_invalid - used as a sentinel and a marker, must be last fixup
   fixup_riscv_invalid,

--- a/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -179,6 +179,10 @@ unsigned RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       FixupKind = RISCV::fixup_riscv_jal;
     } else if (MIFrm == RISCVII::InstFormatB) {
       FixupKind = RISCV::fixup_riscv_branch;
+    } else if (MIFrm == RISCVII::InstFormatCJ) {
+      FixupKind = RISCV::fixup_riscv_rvc_jump;
+    } else if (MIFrm == RISCVII::InstFormatCB) {
+      FixupKind = RISCV::fixup_riscv_rvc_branch;
     }
   }
 

--- a/lib/Target/RISCV/RISCV.td
+++ b/lib/Target/RISCV/RISCV.td
@@ -23,6 +23,11 @@ def FeatureStdExtA : SubtargetFeature<"a", "HasStdExtA", "true",
 def HasStdExtA     :  Predicate<"Subtarget->hasStdExtA()">,
                            AssemblerPredicate<"FeatureStdExtA">;
 
+def FeatureStdExtC : SubtargetFeature<"c", "HasStdExtC", "true",
+                           "'A' (Atomic Instructions)">;
+def HasStdExtC     :  Predicate<"Subtarget->hasStdExtC()">,
+                           AssemblerPredicate<"FeatureStdExtC">;
+
 def FeatureStdExtF : SubtargetFeature<"f", "HasStdExtF", "true",
                            "'F' (Single-Precision Floating-Point)">;
 def HasStdExtF     :  Predicate<"Subtarget->hasStdExtF()">,

--- a/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/lib/Target/RISCV/RISCVInstrFormats.td
@@ -39,7 +39,10 @@ def InstFormatS      : InstFormat<4>;
 def InstFormatB      : InstFormat<5>;
 def InstFormatU      : InstFormat<6>;
 def InstFormatJ      : InstFormat<7>;
-def InstFormatOther  : InstFormat<8>;
+def InstFormatC      : InstFormat<8>;
+def InstFormatCB     : InstFormat<9>;
+def InstFormatCJ     : InstFormat<10>;
+def InstFormatOther  : InstFormat<11>;
 
 // The following opcode names and match those given in Table 19.1 in the
 // RISC-V User-level ISA specification ("RISC-V base opcode map").

--- a/lib/Target/RISCV/RISCVInstrFormatsC.td
+++ b/lib/Target/RISCV/RISCVInstrFormatsC.td
@@ -1,0 +1,84 @@
+//===-- RISCVInstrFormatsC.td - RISCV C Instruction Formats --*- tablegen -*-=//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file describes the RISC-V C extension instruction formats.
+//
+//===----------------------------------------------------------------------===//
+
+class RV16Inst<dag outs, dag ins, string asmstr, list<dag> pattern,
+                  InstFormat format>
+    : Instruction {
+  field bits<16> Inst;
+  // SoftFail is a field the disassembler can use to provide a way for
+  // instructions to not match without killing the whole decode process. It is
+  // mainly used for ARM, but Tablegen expects this field to exist or it fails
+  // to build the decode table.
+  field bits<16> SoftFail = 0;
+  let Size = 2;
+
+  bits<2> Opcode = 0;
+
+  let Namespace = "RISCV";
+
+  dag OutOperandList = outs;
+  dag InOperandList = ins;
+  let AsmString = asmstr;
+  let Pattern = pattern;
+
+  let TSFlags{3-0} = format.Value;
+}
+
+class CI<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<10> imm;
+  bits<5> rd;
+  bits<5> rs1;
+
+  let Inst{15-13} = funct3;
+  let Inst{12} = imm{5};
+  let Inst{11-7} = rd;
+  let Inst{1-0} = opcode;
+}
+
+class CSS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+          string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<10> imm;
+  bits<5> rs2;
+  bits<5> rs1;
+
+  let Inst{15-13} = funct3;
+  let Inst{6-2} = rs2;
+  let Inst{1-0} = opcode;
+}
+
+class CL<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<3> rd;
+  bits<3> rs1;
+
+  let Inst{15-13} = funct3;
+  let Inst{9-7} = rs1;
+  let Inst{4-2} = rd;
+  let Inst{1-0} = opcode;
+}
+
+class CS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<3> rs2;
+  bits<3> rs1;
+
+  let Inst{15-13} = funct3;
+  let Inst{9-7} = rs1;
+  let Inst{4-2} = rs2;
+  let Inst{1-0} = opcode;
+}

--- a/lib/Target/RISCV/RISCVInstrFormatsC.td
+++ b/lib/Target/RISCV/RISCVInstrFormatsC.td
@@ -71,6 +71,17 @@ class CSS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{1-0} = opcode;
 }
 
+class CIW<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<10> imm;
+  bits<3> rd;
+
+  let Inst{15-13} = funct3;
+  let Inst{4-2} = rd;
+  let Inst{1-0} = opcode;
+}
+
 class CL<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
          string asmstr>
     : RV16Inst<outs, ins, asmstr, [], InstFormatC> {

--- a/lib/Target/RISCV/RISCVInstrFormatsC.td
+++ b/lib/Target/RISCV/RISCVInstrFormatsC.td
@@ -34,6 +34,18 @@ class RV16Inst<dag outs, dag ins, string asmstr, list<dag> pattern,
   let TSFlags{3-0} = format.Value;
 }
 
+class CR<bits<4> funct4, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
+  bits<5> rs1;
+  bits<5> rs2;
+
+  let Inst{15-12} = funct4;
+  let Inst{11-7} = rs1;
+  let Inst{6-2} = rs2;
+  let Inst{1-0} = opcode;
+}
+
 class CI<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
          string asmstr>
     : RV16Inst<outs, ins, asmstr, [], InstFormatC> {
@@ -80,5 +92,33 @@ class CS<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
   let Inst{15-13} = funct3;
   let Inst{9-7} = rs1;
   let Inst{4-2} = rs2;
+  let Inst{1-0} = opcode;
+}
+
+class CB<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatCB> {
+  bits<9> imm;
+  bits<3> rs1;
+
+  let Inst{15-13} = funct3;
+  let Inst{9-7} = rs1;
+  let Inst{1-0} = opcode;
+}
+
+class CJ<bits<3> funct3, bits<2> opcode, dag outs, dag ins,
+         string asmstr>
+    : RV16Inst<outs, ins, asmstr, [], InstFormatCJ> {
+  bits<12> offset;
+
+  let Inst{15-13} = funct3;
+  let Inst{12} = offset{11};
+  let Inst{11} = offset{4};
+  let Inst{10-9} = offset{9-8};
+  let Inst{8} = offset{10};
+  let Inst{7} = offset{6};
+  let Inst{6} = offset{7};
+  let Inst{5-3} = offset{3-1};
+  let Inst{2} = offset{5};
   let Inst{1-0} = opcode;
 }

--- a/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -56,7 +56,7 @@ void RISCVInstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
   if (I != MBB.end())
     DL = I->getDebugLoc();
 
-  if (RC == &RISCV::GPRRegClass)
+  if (RC == &RISCV::GPRRegClass || RC == &RISCV::GPRCRegClass)
     BuildMI(MBB, I, DL, get(RISCV::SW_FI))
         .addReg(SrcReg, getKillRegState(IsKill))
         .addFrameIndex(FI)
@@ -74,7 +74,7 @@ void RISCVInstrInfo::loadRegFromStackSlot(MachineBasicBlock &MBB,
   if (I != MBB.end())
     DL = I->getDebugLoc();
 
-  if (RC == &RISCV::GPRRegClass)
+  if (RC == &RISCV::GPRRegClass || RC == &RISCV::GPRCRegClass)
     BuildMI(MBB, I, DL, get(RISCV::LW_FI), DestReg).addFrameIndex(FI).addImm(0);
   else
     llvm_unreachable("Can't load this register from stack slot");

--- a/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/lib/Target/RISCV/RISCVInstrInfo.td
@@ -509,5 +509,6 @@ def ADJCALLSTACKUP   : Pseudo<(outs), (ins i32imm:$amt1, i32imm:$amt2),
 
 include "RISCVInstrInfoM.td"
 include "RISCVInstrInfoA.td"
+include "RISCVInstrInfoC.td"
 include "RISCVInstrInfoF.td"
 include "RISCVInstrInfoD.td"

--- a/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -1,0 +1,93 @@
+//===- RISCVInstrInfoC.td - Compressed RISCV instructions -*- tblgen-*-----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+include "RISCVInstrFormatsC.td"
+
+//===----------------------------------------------------------------------===//
+// Operand definitions.
+//===----------------------------------------------------------------------===//
+
+// A 8-bit unsigned immediate where the least two bits are zero.
+def uimm8_lsb00 : Operand<XLenVT>,
+                 ImmLeaf<XLenVT, [{return isShiftedUInt<6, 2>(Imm);}]> {
+  let ParserMatchClass = UImmAsmOperand<8, "Lsb00">;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeUImmOperand<8>";
+}
+
+// A 7-bit unsigned immediate where the least two bits are zero.
+def uimm7_lsb00 : Operand<XLenVT>,
+                 ImmLeaf<XLenVT, [{return isShiftedUInt<5, 2>(Imm);}]> {
+  let ParserMatchClass = UImmAsmOperand<7, "Lsb00">;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeUImmOperand<7>";
+}
+
+//===----------------------------------------------------------------------===//
+// Instruction Class Templates
+//===----------------------------------------------------------------------===//
+
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
+class Stack_Load<bits<3> funct3, string OpcodeStr,
+                 RegisterClass cls> :
+      CI<funct3, 0b10, (outs cls:$rd), (ins SP:$rs1, uimm8_lsb00:$imm),
+         OpcodeStr#"\t$rd, ${imm}(${rs1})">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
+class Stack_Store<bits<3> funct3, string OpcodeStr,
+                  RegisterClass cls> :
+      CSS<funct3, 0b10, (outs), (ins cls:$rs2, SP:$rs1, uimm8_lsb00:$imm),
+          OpcodeStr#"\t$rs2, ${imm}(${rs1})">;
+
+let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
+class Reg_Load<bits<3> funct3, string OpcodeStr, SDPatternOperator Op,
+               RegisterClass cls> :
+      CL<funct3, 0b00, (outs cls:$rd), (ins cls:$rs1, uimm7_lsb00:$imm),
+         OpcodeStr#"\t$rd, ${imm}(${rs1})">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
+class Reg_Store<bits<3> funct3, string OpcodeStr, SDPatternOperator Op,
+                RegisterClass cls> :
+      CS<funct3, 0b00, (outs), (ins cls:$rs2, cls:$rs1, uimm7_lsb00:$imm),
+         OpcodeStr#"\t$rs2, ${imm}(${rs1})">;
+
+//===----------------------------------------------------------------------===//
+// Stack-Pointer-Based Loads and Stores
+//===----------------------------------------------------------------------===//
+
+def CLWSP  : Stack_Load<0b010, "c.lwsp", GPR>,
+             Requires<[HasStdExtC]> {
+  let Inst{6-4} = imm{4-2};
+  let Inst{3-2} = imm{7-6};
+}
+
+def CSWSP  : Stack_Store<0b110, "c.swsp", GPR>,
+             Requires<[HasStdExtC]> {
+  let Inst{12-9} = imm{5-2};
+  let Inst{8-7}  = imm{7-6};
+}
+
+//===----------------------------------------------------------------------===//
+// Register-Based Loads and Stores
+//===----------------------------------------------------------------------===//
+
+def CLW  : Reg_Load<0b010, "c.lw", load, GPRC>, Requires<[HasStdExtC]> {
+  bits<7> imm;
+  let Inst{12-10} = imm{5-3};
+  let Inst{6} = imm{2};
+  let Inst{5} = imm{6};
+}
+
+def CSW  : Reg_Store<0b110, "c.sw", store, GPRC>,
+           Requires<[HasStdExtC]> {
+  bits<7> imm;
+  let Inst{12-10} = imm{5-3};
+  let Inst{6} = imm{2};
+  let Inst{5} = imm{6};
+}

--- a/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -13,9 +13,20 @@ include "RISCVInstrFormatsC.td"
 // Operand definitions.
 //===----------------------------------------------------------------------===//
 
+def uimm6 : Operand<XLenVT>, ImmLeaf<XLenVT, [{return isUInt<6>(Imm);}]> {
+  let ParserMatchClass = UImmAsmOperand<6>;
+  let DecoderMethod = "decodeUImmOperand<6>";
+}
+
+def simm6 : Operand<XLenVT>, ImmLeaf<XLenVT, [{return isInt<6>(Imm);}]> {
+  let ParserMatchClass = SImmAsmOperand<6>;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeSImmOperand<6>";
+}
+
 // A 8-bit unsigned immediate where the least two bits are zero.
 def uimm8_lsb00 : Operand<XLenVT>,
-                 ImmLeaf<XLenVT, [{return isShiftedUInt<6, 2>(Imm);}]> {
+                  ImmLeaf<XLenVT, [{return isShiftedUInt<6, 2>(Imm);}]> {
   let ParserMatchClass = UImmAsmOperand<8, "Lsb00">;
   let EncoderMethod = "getImmOpValue";
   let DecoderMethod = "decodeUImmOperand<8>";
@@ -23,7 +34,7 @@ def uimm8_lsb00 : Operand<XLenVT>,
 
 // A 7-bit unsigned immediate where the least two bits are zero.
 def uimm7_lsb00 : Operand<XLenVT>,
-                 ImmLeaf<XLenVT, [{return isShiftedUInt<5, 2>(Imm);}]> {
+                  ImmLeaf<XLenVT, [{return isShiftedUInt<5, 2>(Imm);}]> {
   let ParserMatchClass = UImmAsmOperand<7, "Lsb00">;
   let EncoderMethod = "getImmOpValue";
   let DecoderMethod = "decodeUImmOperand<7>";
@@ -41,6 +52,20 @@ def simm12_lsb0 : Operand<OtherVT> {
   let ParserMatchClass = SImmAsmOperand<12, "Lsb0">;
   let EncoderMethod = "getImmOpValueAsr1";
   let DecoderMethod = "decodeSImmOperandAndLsl1<12>";
+}
+
+def uimm10_2lsb0 : Operand<XLenVT>,
+                   ImmLeaf<XLenVT, [{return isShiftedUInt<8, 2>(Imm);}]> {
+  let ParserMatchClass = UImmAsmOperand<10, "Lsb00">;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeUImmOperand<10>";
+}
+
+def simm10_4lsb0 : Operand<XLenVT>,
+                   ImmLeaf<XLenVT, [{return isShiftedInt<6, 4>(Imm);}]> {
+  let ParserMatchClass = SImmAsmOperand<10, "Lsb0000">;
+  let EncoderMethod = "getImmOpValue";
+  let DecoderMethod = "decodeSImmOperand<10>";
 }
 
 //===----------------------------------------------------------------------===//
@@ -114,6 +139,109 @@ class Bcz<bits<3> funct3, string OpcodeStr, PatFrag CondOp,
   let Inst{2} = imm{5};
 }
 
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Move_Imm<RegisterClass cls, Operand ImmOpnd> :
+      CI<0b010, 0b01, (outs cls:$rd), (ins ImmOpnd:$imm),
+         "c.li\t$rd, $imm"> {
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Move_High<RegisterClass cls, Operand ImmOpnd> :
+      CI<0b011, 0b01, (outs cls:$rd), (ins ImmOpnd:$imm),
+         "c.lui\t$rd, $imm"> {
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Add_Imm<RegisterClass cls, Operand ImmOpnd> :
+      CI<0b000, 0b01, (outs cls:$rd_wb), (ins cls:$rd, ImmOpnd:$imm),
+         "c.addi\t$rd, $imm"> {
+  let Constraints = "$rd = $rd_wb";
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class ADDI_16SP<RegisterClass cls> :
+      CI<0b011, 0b01, (outs cls:$rd_wb),
+         (ins cls:$rd, simm10_4lsb0:$imm),
+         "c.addi16sp\t$rd, $imm"> {
+  let Constraints = "$rd = $rd_wb";
+  let Inst{12} = imm{9};
+  let Inst{11-7} = 2;
+  let Inst{6} = imm{4};
+  let Inst{5} = imm{6};
+  let Inst{4-3} = imm{8-7};
+  let Inst{2} = imm{5};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class ADDI_4SPN<RegisterClass cls, RegisterClass spcls> :
+      CIW<0b000, 0b00, (outs cls:$rd),
+          (ins spcls:$rs1, uimm10_2lsb0:$imm),
+          "c.addi4spn\t$rd, $rs1, $imm"> {
+  bits<5> rs1;
+  let Inst{12-11} = imm{5-4};
+  let Inst{10-7} = imm{9-6};
+  let Inst{6} = imm{2};
+  let Inst{5} = imm{3};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Shift_left<RegisterClass cls, Operand ImmOpnd> :
+      CI<0b000, 0b10, (outs cls:$rd_wb),
+         (ins cls:$rd, ImmOpnd:$imm),
+         "c.slli\t$rd, $imm"> {
+  let Constraints = "$rd = $rd_wb";
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Shift_right<bits<2> funct2, string OpcodeStr, SDPatternOperator OpNode,
+                  RegisterClass cls, Operand ImmOpnd> :
+      CB<0b100, 0b01, (outs cls:$rs1_wb), (ins cls:$rs1, ImmOpnd:$imm),
+         OpcodeStr#"\t$rs1, $imm"> {
+  let Constraints = "$rs1 = $rs1_wb";
+  let Inst{12} = imm{5};
+  let Inst{11-10} = funct2;
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class And_Imm<RegisterClass cls, Operand ImmOpnd> :
+      CB<0b100, 0b01, (outs cls:$rs1_wb), (ins cls:$rs1, ImmOpnd:$imm),
+               "c.andi\t$rs1, $imm"> {
+  let Constraints = "$rs1 = $rs1_wb";
+  let Inst{12} = imm{5};
+  let Inst{11-10} = 0b10;
+  let Inst{6-2} = imm{4-0};
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Move_Reg<RegisterClass cls> :
+      CR<0b1000, 0b10, (outs cls:$rs1), (ins cls:$rs2),
+         "c.mv\t$rs1, $rs2">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Add_Reg<RegisterClass cls> :
+      CR<0b1001, 0b10, (outs cls:$rs1_wb), (ins cls:$rs1, cls:$rs2),
+              "c.add\t$rs1, $rs2"> {
+  let Constraints = "$rs1 = $rs1_wb";
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class CS_ALU<bits<2> funct2, string OpcodeStr, SDPatternOperator OpNode,
+             RegisterClass cls, bit RV64only> :
+      CS<0b100, 0b01, (outs cls:$rd_wb), (ins cls:$rd, cls:$rs2),
+         OpcodeStr#"\t$rd, $rs2"> {
+  bits<3> rd;
+  let Constraints = "$rd = $rd_wb";
+  let Inst{12} = RV64only;
+  let Inst{11-10} = 0b11;
+  let Inst{9-7} = rd;
+  let Inst{6-5} = funct2;
+}
+
 //===----------------------------------------------------------------------===//
 // Stack-Pointer-Based Loads and Stores
 //===----------------------------------------------------------------------===//
@@ -163,3 +291,41 @@ def CJALR : Call_Reg<GPR>, Requires<[HasStdExtC]>;
 
 def CBEQZ   : Bcz<0b110, "c.beqz",  seteq, GPRC>, Requires<[HasStdExtC]>;
 def CBNEZ   : Bcz<0b111, "c.bnez",  setne, GPRC>, Requires<[HasStdExtC]>;
+
+//===----------------------------------------------------------------------===//
+// Integer Computational Instructions
+//===----------------------------------------------------------------------===//
+
+def CLI   : Move_Imm<GPR, simm6>, Requires<[HasStdExtC]>;
+
+def CLUI   : Move_High<GPR, uimm6>, Requires<[HasStdExtC]>;
+
+def CADDI   : Add_Imm<GPR, simm6>, Requires<[HasStdExtC]>;
+
+def CADDI16SP : ADDI_16SP<SP>, Requires<[HasStdExtC]>;
+
+def CADDI4SPN : ADDI_4SPN<GPRC, SP>, Requires<[HasStdExtC]>;
+
+def CSLLI   : Shift_left<GPR, uimm5>, Requires<[HasStdExtC]>;
+
+def CSRLI   : Shift_right<0b00, "c.srli",  srl, GPRC,   uimm5>,
+              Requires<[HasStdExtC]>;
+def CSRAI   : Shift_right<0b01, "c.srai",  sra, GPRC,   uimm5>,
+              Requires<[HasStdExtC]>;
+
+def CANDI  : And_Imm<GPRC, simm6>, Requires<[HasStdExtC]>;
+
+def CMV    : Move_Reg<GPR>, Requires<[HasStdExtC]>;
+
+def CADD   : Add_Reg<GPR>, Requires<[HasStdExtC]>;
+
+def CAND   : CS_ALU<0b11, "c.and",  and, GPRC, 0>, Requires<[HasStdExtC]>;
+def COR    : CS_ALU<0b10, "c.or" ,   or, GPRC, 0>, Requires<[HasStdExtC]>;
+def CXOR   : CS_ALU<0b01, "c.xor",  xor, GPRC, 0>, Requires<[HasStdExtC]>;
+def CSUB   : CS_ALU<0b00, "c.sub",  sub, GPRC, 0>, Requires<[HasStdExtC]>;
+
+let rd = 0, imm = 0, hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def CNOP : CI<0b000, 0b01, (outs), (ins), "c.nop">, Requires<[HasStdExtC]>;
+
+let rs1 = 0, rs2 = 0, hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+def CEBREAK : CR<0b1001, 0b10, (outs), (ins), "c.ebreak">, Requires<[HasStdExtC]>;

--- a/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -29,6 +29,20 @@ def uimm7_lsb00 : Operand<XLenVT>,
   let DecoderMethod = "decodeUImmOperand<7>";
 }
 
+// A 9-bit signed immediate where the least significant bit is zero.
+def simm9_lsb0 : Operand<OtherVT> {
+  let ParserMatchClass = SImmAsmOperand<9, "Lsb0">;
+  let EncoderMethod = "getImmOpValueAsr1";
+  let DecoderMethod = "decodeSImmOperandAndLsl1<9>";
+}
+
+// A 12-bit signed immediate where the least significant bit is zero.
+def simm12_lsb0 : Operand<OtherVT> {
+  let ParserMatchClass = SImmAsmOperand<12, "Lsb0">;
+  let EncoderMethod = "getImmOpValueAsr1";
+  let DecoderMethod = "decodeSImmOperandAndLsl1<12>";
+}
+
 //===----------------------------------------------------------------------===//
 // Instruction Class Templates
 //===----------------------------------------------------------------------===//
@@ -56,6 +70,49 @@ class Reg_Store<bits<3> funct3, string OpcodeStr, SDPatternOperator Op,
                 RegisterClass cls> :
       CS<funct3, 0b00, (outs), (ins cls:$rs2, cls:$rs1, uimm7_lsb00:$imm),
          OpcodeStr#"\t$rs2, ${imm}(${rs1})">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Jump_Imm : CJ<0b101, 0b01, (outs), (ins simm12_lsb0:$offset),
+                    "c.j\t$offset"> {
+  let isBranch = 1;
+  let isTerminator=1;
+  let isBarrier=1;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCall = 1 in
+class Call_Imm : CJ<0b001, 0b01, (outs), (ins simm12_lsb0:$offset),
+                    "c.jal\t$offset">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Jump_Reg<RegisterClass cls> :
+      CR<0b1000, 0b10, (outs), (ins cls:$rs1),
+         "c.jr\t$rs1"> {
+  let isBranch = 1;
+  let isBarrier = 1;
+  let isTerminator = 1;
+  let isIndirectBranch = 1;
+  let rs2 = 0;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0,
+    isCall=1, Defs=[X1], rs2 = 0 in
+class Call_Reg<RegisterClass cls> :
+      CR<0b1001, 0b10, (outs), (ins cls:$rs1),
+         "c.jalr\t$rs1">;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class Bcz<bits<3> funct3, string OpcodeStr, PatFrag CondOp,
+          RegisterClass cls> :
+      CB<funct3, 0b01, (outs), (ins cls:$rs1, simm9_lsb0:$imm),
+         OpcodeStr#"\t$rs1, $imm"> {
+  let isBranch = 1;
+  let isTerminator = 1;
+  let Inst{12} = imm{8};
+  let Inst{11-10} = imm{4-3};
+  let Inst{6-5} = imm{7-6};
+  let Inst{4-3} = imm{2-1};
+  let Inst{2} = imm{5};
+}
 
 //===----------------------------------------------------------------------===//
 // Stack-Pointer-Based Loads and Stores
@@ -91,3 +148,18 @@ def CSW  : Reg_Store<0b110, "c.sw", store, GPRC>,
   let Inst{6} = imm{2};
   let Inst{5} = imm{6};
 }
+
+//===----------------------------------------------------------------------===//
+// Control Transfer Instructions
+//===----------------------------------------------------------------------===//
+
+def CJ : Jump_Imm, Requires<[HasStdExtC]>;
+
+def CJAL : Call_Imm, Requires<[HasStdExtC]>;
+
+def CJR : Jump_Reg<GPR>, Requires<[HasStdExtC]>;
+
+def CJALR : Call_Reg<GPR>, Requires<[HasStdExtC]>;
+
+def CBEQZ   : Bcz<0b110, "c.beqz",  seteq, GPRC>, Requires<[HasStdExtC]>;
+def CBNEZ   : Bcz<0b111, "c.bnez",  setne, GPRC>, Requires<[HasStdExtC]>;

--- a/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -93,6 +93,21 @@ def GPR : RegisterClass<"RISCV", [XLenVT], 32, (add
       [RegInfo<32,32,32>, RegInfo<64,64,64>, RegInfo<32,32,32>]>;
 }
 
+def GPRC : RegisterClass<"RISCV", [XLenVT], 32, (add
+    (sequence "X%u", 10, 15),
+    (sequence "X%u", 8, 9)
+  )> {
+  let RegInfos = RegInfoByHwMode<
+      [RV32,              RV64,              DefaultMode],
+      [RegInfo<32,32,32>, RegInfo<64,64,64>, RegInfo<32,32,32>]>;
+}
+
+def SP : RegisterClass<"RISCV", [XLenVT], 32, (add X2)> {
+  let RegInfos = RegInfoByHwMode<
+      [RV32,              RV64,              DefaultMode],
+      [RegInfo<32,32,32>, RegInfo<64,64,64>, RegInfo<32,32,32>]>;
+}
+
 // Floating point registers
 let RegAltNameIndices = [ABIRegAltName] in {
   def F0_32  : RISCVReg32<0, "f0", ["ft0"]>, DwarfRegNum<[32]>;

--- a/lib/Target/RISCV/RISCVSubtarget.h
+++ b/lib/Target/RISCV/RISCVSubtarget.h
@@ -32,6 +32,7 @@ class RISCVSubtarget : public RISCVGenSubtargetInfo {
   virtual void anchor();
   bool HasStdExtM = false;
   bool HasStdExtA = false;
+  bool HasStdExtC = false;
   bool HasStdExtF = false;
   bool HasStdExtD = false;
   bool HasRV64 = false;
@@ -72,6 +73,7 @@ public:
   }
   bool hasStdExtM() const { return HasStdExtM; }
   bool hasStdExtA() const { return HasStdExtA; }
+  bool hasStdExtC() const { return HasStdExtC; }
   bool hasStdExtF() const { return HasStdExtF; }
   bool is64Bit() const { return HasRV64; }
   MVT getXLenVT() const { return XLenVT; }

--- a/test/MC/RISCV/compressed-invalid.s
+++ b/test/MC/RISCV/compressed-invalid.s
@@ -1,0 +1,14 @@
+# RUN: not llvm-mc -mattr=+c < %s 2>&1 | FileCheck %s
+
+## GPRC
+c.lw  ra, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
+c.sw  sp, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
+
+# Out of range immediates
+
+## uimm8_lsb00
+c.lwsp  ra, 300(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
+c.swsp  ra, -20(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 4 bytes in the range [0, 252]
+## uimm7_lsb00
+c.lw  s0, -4(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
+c.sw  s0, 130(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]

--- a/test/MC/RISCV/compressed-invalid.s
+++ b/test/MC/RISCV/compressed-invalid.s
@@ -6,6 +6,18 @@ c.lw  ra, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
 c.sw  sp, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
 c.beqz  t0, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
 c.bnez  s8, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.addi4spn  s4, sp, 12 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
+c.srli  s7, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.srai  t0, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.andi  t1, 12 # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.and  t1, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+c.or   a0, s8 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
+c.xor  t2, a0 # CHECK: :[[@LINE]]:8: error: invalid operand for instruction
+c.sub  a0, s8 # CHECK: :[[@LINE]]:12: error: invalid operand for instruction
+
+## SP
+c.addi4spn  a0, a0, 12 # CHECK: :[[@LINE]]:17: error: invalid operand for instruction
+c.addi16sp  t0, 16 # CHECK: :[[@LINE]]:13: error: invalid operand for instruction
 
 # Out of range immediates
 
@@ -23,3 +35,26 @@ c.beqz  a0, 280 # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 2
 ## simm12_lsb0
 c.j 4096 # CHECK: :[[@LINE]]:5: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
 c.jal -3000 # CHECK: :[[@LINE]]:7: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
+
+## simm6
+c.li t0, 128 # CHECK: :[[@LINE]]:10: error: immediate must be an integer in the range [-32, 31]
+c.addi t0, 64 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
+c.andi a0, -64 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [-32, 31]
+
+## uimm6
+c.lui t0, 128 # CHECK: :[[@LINE]]:11: error: immediate must be an integer in the range [0, 63]
+
+## uimm10_2lsb0
+c.addi4spn  a0, sp, 2048 # CHECK: :[[@LINE]]:21: error: immediate must be a multiple of 4 bytes in the range [0, 1020]
+c.addi4spn  a0, sp, -4 # CHECK: :[[@LINE]]:21: error: immediate must be a multiple of 4 bytes in the range [0, 1020]
+c.addi4spn  a0, sp, 2 # CHECK: :[[@LINE]]:21: error: immediate must be a multiple of 4 bytes in the range [0, 1020]
+
+## simm10_4lsb0
+c.addi16sp  sp, 2048 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes in the range [-1024, 1008]
+c.addi16sp  sp, -2048 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes in the range [-1024, 1008]
+c.addi16sp  sp, 8 # CHECK: :[[@LINE]]:17: error: immediate must be a multiple of 16 bytes in the range [-1024, 1008]
+
+## uimm5
+c.slli t0, 64 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]
+c.srli a0, 32 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]
+c.srai a0, -1 # CHECK: :[[@LINE]]:12: error: immediate must be an integer in the range [0, 31]

--- a/test/MC/RISCV/compressed-invalid.s
+++ b/test/MC/RISCV/compressed-invalid.s
@@ -1,8 +1,11 @@
 # RUN: not llvm-mc -mattr=+c < %s 2>&1 | FileCheck %s
 
+.LBB:
 ## GPRC
 c.lw  ra, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
 c.sw  sp, 4(sp) # CHECK: :[[@LINE]]:7: error: invalid operand for instruction
+c.beqz  t0, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
+c.bnez  s8, .LBB # CHECK: :[[@LINE]]:9: error: invalid operand for instruction
 
 # Out of range immediates
 
@@ -12,3 +15,11 @@ c.swsp  ra, -20(sp) # CHECK: :[[@LINE]]:13: error: immediate must be a multiple 
 ## uimm7_lsb00
 c.lw  s0, -4(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
 c.sw  s0, 130(sp) # CHECK: :[[@LINE]]:11: error: immediate must be a multiple of 4 bytes in the range [0, 124]
+
+## simm9_lsb0
+c.bnez  s1, -1028 # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
+c.beqz  a0, 280 # CHECK: :[[@LINE]]:13: error: immediate must be a multiple of 2 bytes in the range [-256, 254]
+
+## simm12_lsb0
+c.j 4096 # CHECK: :[[@LINE]]:5: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]
+c.jal -3000 # CHECK: :[[@LINE]]:7: error: immediate must be a multiple of 2 bytes in the range [-2048, 2046]

--- a/test/MC/RISCV/compressed-valid.s
+++ b/test/MC/RISCV/compressed-valid.s
@@ -16,3 +16,18 @@ c.lw    a2, 4(a0)
 # CHECK: encoding: [0x9c,0xc6]
 c.sw    a5, 8(a3)
 
+# CHECK-INST: c.j     -16
+# CHECK: encoding: [0xe5,0xbf]
+c.j     -16
+# CHECK-INST: c.jr    a7
+# CHECK: encoding: [0x82,0x88]
+c.jr    a7
+# CHECK-INST: c.jalr  a1
+# CHECK: encoding: [0x82,0x95]
+c.jalr  a1
+# CHECK-INST: c.beqz  a3, -8
+# CHECK: encoding: [0xf5,0xde]
+c.beqz  a3, -8
+# CHECK-INST: c.bnez  a5, -12
+# CHECK: encoding: [0xed,0xff]
+c.bnez  a5, -12

--- a/test/MC/RISCV/compressed-valid.s
+++ b/test/MC/RISCV/compressed-valid.s
@@ -31,3 +31,55 @@ c.beqz  a3, -8
 # CHECK-INST: c.bnez  a5, -12
 # CHECK: encoding: [0xed,0xff]
 c.bnez  a5, -12
+
+# CHECK-INST: c.li  a7, 31
+# CHECK: encoding: [0xfd,0x48]
+c.li    a7, 31
+# CHECK-INST: c.addi  a3, 15
+# CHECK: encoding: [0xbd,0x06]
+c.addi  a3, 15
+# CHECK-INST: c.addi16sp  sp, -16
+# CHECK: encoding: [0x7d,0x71]
+c.addi16sp  sp, -16
+# CHECK-INST: c.addi4spn  a3, sp, 16
+# CHECK: encoding: [0x14,0x08]
+c.addi4spn      a3, sp, 16
+# CHECK-INST: c.slli  a1, 2
+# CHECK: encoding: [0x8a,0x05]
+c.slli  a1, 2
+# CHECK-INST: c.srli  a3, 3
+# CHECK: encoding: [0x8d,0x82]
+c.srli  a3, 3
+# CHECK-INST: c.srai  a4, 2
+# CHECK: encoding: [0x09,0x87]
+c.srai  a4, 2
+# CHECK-INST: c.andi  a5, 15
+# CHECK: encoding: [0xbd,0x8b]
+c.andi  a5, 15
+# CHECK-INST: c.mv    a7, s0
+# CHECK: encoding: [0xa2,0x88]
+c.mv    a7, s0
+# CHECK-INST: c.and   a1, a2
+# CHECK: encoding: [0xf1,0x8d]
+c.and   a1, a2
+# CHECK-INST: c.or    a2, a3
+# CHECK: encoding: [0x55,0x8e]
+c.or    a2, a3
+# CHECK-INST: c.xor   a3, a4
+# CHECK: encoding: [0xb9,0x8e]
+c.xor   a3, a4
+# CHECK-INST: c.sub   a4, a5
+# CHECK: encoding: [0x1d,0x8f]
+c.sub   a4, a5
+# CHECK-INST: c.nop
+# CHECK: encoding: [0x01,0x00]
+c.nop
+# CHECK-INST: c.ebreak
+# CHECK: encoding: [0x02,0x90]
+c.ebreak
+# CHECK-INST: c.jal   256
+# CHECK: encoding: [0x41,0x20]
+c.jal   256
+# CHECK-INST: c.lui   s0, 30
+# CHECK: encoding: [0x79,0x64]
+c.lui   s0, 30

--- a/test/MC/RISCV/compressed-valid.s
+++ b/test/MC/RISCV/compressed-valid.s
@@ -1,0 +1,18 @@
+# RUN: llvm-mc %s -mattr=+c -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-INST %s
+# RUN: llvm-mc -filetype=obj -mattr=+c < %s \
+# RUN:     | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INST %s
+
+# CHECK-INST: c.lwsp  ra, 12(sp)
+# CHECK: encoding: [0xb2,0x40]
+c.lwsp  ra, 12(sp)
+# CHECK-INST: c.swsp  ra, 12(sp)
+# CHECK: encoding: [0x06,0xc6]
+c.swsp  ra, 12(sp)
+# CHECK-INST: c.lw    a2, 4(a0)
+# CHECK: encoding: [0x50,0x41]
+c.lw    a2, 4(a0)
+# CHECK-INST: c.sw    a5, 8(a3)
+# CHECK: encoding: [0x9c,0xc6]
+c.sw    a5, 8(a3)
+

--- a/test/MC/RISCV/fixups-compressed.s
+++ b/test/MC/RISCV/fixups-compressed.s
@@ -1,0 +1,19 @@
+# RUN: llvm-mc %s -mattr=+c -show-encoding \
+# RUN:     | FileCheck -check-prefix=CHECK-FIXUP %s
+# RUN: llvm-mc -filetype=obj -mattr=+c < %s \
+# RUN:     | llvm-objdump -d - | FileCheck -check-prefix=CHECK-INSTR %s
+
+.LBB0_2:
+# CHECK-FIXUP: encoding: [0bAAAAAA01,0b101AAAAA]
+# CHECK-FIXUP:   fixup A - offset: 0, value: .LBB0_2, kind: fixup_riscv_rvc_jump
+# CHECK-INSTR: c.j     0
+c.j     .LBB0_2
+# CHECK-FIXUP: encoding: [0bAAAAAA01,0b110AAAAA]
+# CHECK-FIXUP:   fixup A - offset: 0, value: .LBB0_2, kind: fixup_riscv_rvc_branch
+# CHECK-INSTR: c.beqz  a3, -4
+c.beqz  a3, .LBB0_2
+# CHECK-FIXUP: encoding: [0bAAAAAA01,0b111AAAAA]
+# CHECK-FIXUP:   fixup A - offset: 0, value: .LBB0_2, kind: fixup_riscv_rvc_branch
+# CHECK-INSTR: c.bnez  a5, -8
+c.bnez  a5, .LBB0_2
+

--- a/test/MC/RISCV/fixups-compressed.s
+++ b/test/MC/RISCV/fixups-compressed.s
@@ -17,3 +17,6 @@ c.beqz  a3, .LBB0_2
 # CHECK-INSTR: c.bnez  a5, -8
 c.bnez  a5, .LBB0_2
 
+# CHECK: encoding: [0bAAAAAA01,0b001AAAAA]
+# CHECK:   fixup A - offset: 0, value: func1, kind: fixup_riscv_rvc_jump
+c.jal   func1

--- a/test/MC/RISCV/relocations.s
+++ b/test/MC/RISCV/relocations.s
@@ -1,6 +1,6 @@
-# RUN: llvm-mc -triple riscv32 < %s -show-encoding \
+# RUN: llvm-mc -triple riscv32 -mattr=+c < %s -show-encoding \
 # RUN:     | FileCheck -check-prefix=INSTR -check-prefix=FIXUP %s
-# RUN: llvm-mc -filetype=obj -triple riscv32 < %s \
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+c < %s \
 # RUN:     | llvm-readobj -r | FileCheck -check-prefix=RELOC %s
 
 # Check prefixes:
@@ -63,3 +63,13 @@ bgeu a0, a1, foo
 # RELOC: R_RISCV_BRANCH
 # INSTR: bgeu a0, a1, foo
 # FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_branch
+
+c.jal foo
+# RELOC: R_RISCV_RVC_JUMP
+# INSTR: c.jal foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_rvc_jump
+
+c.bnez a0, foo
+# RELOC: R_RISCV_RVC_BRANCH
+# INSTR: c.bnez a0, foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_rvc_branch


### PR DESCRIPTION
Hi Alex,

I commit the patches as follow

1. Extract RISCV operands definition to RISCVOperands.td
    Hopefully it could reduce the merge effort in the future.
   
2. Add RISCVFeature.td to describe target feature (C/M/E/A)

3. Add infrastructures that RISCVAsmParser could get target feature
    Then the RVC MC test case could parse C extension instructions

4. Add infrastructures that RISCV Disassembler could get target feature
    Then the RVC MC test case could disassemble C extension instructions

5. Add c.swsp c.lwsp c.lw c.sw C extension instructions and MC testcases

6. Add c.swsp c.lwsp c.lw c.sw codegen implementation and CodeGen testcases

7. WriteNopData support generating c.nop when target support C extension

Please help me to review the patches to make the quality better.
The rest C extension instructions patch set should coming soon.